### PR TITLE
Issue #6 password salt

### DIFF
--- a/Model/AccountGroup.cs
+++ b/Model/AccountGroup.cs
@@ -13,6 +13,7 @@ namespace kPassKeep.Model
             RawMembers = new Dictionary<Guid, RawSimpleEntity>();
         }
         public IDictionary<Guid, RawSimpleEntity> RawMembers { get; private set; }
+        public Version FormatVersion { get; set; }
     }
 
     public class ModificationTracker
@@ -38,6 +39,7 @@ namespace kPassKeep.Model
         {
             ModificationTracker = new ModificationTracker();
             RawAccountGroup = new RawAccountGroup();
+            RawAccountGroup.FormatVersion = kPassKeep.Service.PersistenceProvider.LatestFormat;
             RawAccountGroup.Guid = Guid;
         }
 

--- a/Model/AccountGroup.cs
+++ b/Model/AccountGroup.cs
@@ -14,6 +14,8 @@ namespace kPassKeep.Model
         }
         public IDictionary<Guid, RawSimpleEntity> RawMembers { get; private set; }
         public Version FormatVersion { get; set; }
+        public byte[] PasswordHash { get; set; }
+        public byte[] Salt { get; set; }
     }
 
     public class ModificationTracker

--- a/Service/PersistenceProvider.cs
+++ b/Service/PersistenceProvider.cs
@@ -367,6 +367,7 @@ namespace kPassKeep.Service
         public string name;
         public string descr;
         public byte[] pass;
+        public byte[] salt;
         public RawSimpleEntity[] members;
     }
     class SerializableEntity


### PR DESCRIPTION
Пароль теперь сохраняется в виде хэша, смешанного с солью, и самой соли.

Изменение полностью совместимо с предыдущей версией в одностороннем режиме -- чтение производится в старом формате, запись -- в новом.